### PR TITLE
Rack params have string keys not symbols

### DIFF
--- a/lib/warden/oauth2/strategies/client.rb
+++ b/lib/warden/oauth2/strategies/client.rb
@@ -25,7 +25,7 @@ module Warden
         end
 
         def client_from_request_params
-          @client_id, @client_secret = params[:client_id], params[:client_secret]
+          @client_id, @client_secret = params['client_id'], params['client_secret']
           return nil unless self.client_id
           Warden::OAuth2.config.client_model.locate(@client_id, @client_secret)
         end

--- a/spec/warden/oauth2/strategies/client_spec.rb
+++ b/spec/warden/oauth2/strategies/client_spec.rb
@@ -26,18 +26,18 @@ describe Warden::OAuth2::Strategies::Client do
 
   describe '#client_from_request_params' do
     it 'should be nil if no client_id is provided' do
-      subject.stub!(:params).and_return({:client_secret => 'abc'})
+      subject.stub!(:params).and_return({'client_secret' => 'abc'})
       subject.client_from_request_params.should be_nil
     end
 
     it 'should call through to locate if a client_id is present' do
-      subject.stub!(:params).and_return({:client_id => 'abc'})
+      subject.stub!(:params).and_return({'client_id' => 'abc'})
       client_model.should_receive(:locate).with('abc',nil)
       subject.client_from_request_params
     end
 
     it 'should call through to locate if a client_id and secret are present' do
-      subject.stub!(:params).and_return({:client_id => 'abc', :client_secret => 'def'})
+      subject.stub!(:params).and_return({'client_id' => 'abc', 'client_secret' => 'def'})
       client_model.should_receive(:locate).with('abc','def')
       subject.client_from_request_params
     end
@@ -47,7 +47,7 @@ describe Warden::OAuth2::Strategies::Client do
     it 'should succeed if a client is around' do
       client_instance = mock
       client_model.stub!(:locate).and_return(client_instance)
-      subject.stub!(:params).and_return(:client_id => 'awesome')
+      subject.stub!(:params).and_return('client_id' => 'awesome')
       subject._run!
       subject.user.should == client_instance
       subject.result.should == :success
@@ -62,7 +62,7 @@ describe Warden::OAuth2::Strategies::Client do
 
     it 'should fail if insufficient scope is provided' do
       client_model.stub!(:locate).and_return(mock(:respond_to? => true, :scope? => false))
-      subject.stub!(:params).and_return(:client_id => 'abc')
+      subject.stub!(:params).and_return('client_id' => 'abc')
       subject.stub!(:scope).and_return(:confidential_client)
       subject._run!
       subject.result.should == :failure


### PR DESCRIPTION
Tried to use parameters in query string with Grape and found out that query string params that got passed to warden strategy are stored with string key not with symbol key. I believe, keys will be symbols only if you're running inside Rails and rails wraps params into HashWithIndifferentAccess. Anyway string keys should be supported by both Rails and plain Rack stacks.
