### PR TITLE
Fail with `invalid_token` if a Bearer token was provided, but was not located

### DIFF
--- a/lib/warden/oauth2/strategies/bearer.rb
+++ b/lib/warden/oauth2/strategies/bearer.rb
@@ -8,6 +8,11 @@ module Warden
           !!token_string
         end
 
+        def authenticate!
+          fail! "invalid_token" and return if token_string && !token
+          super
+        end
+
         def token_string
           token_string_from_header || token_string_from_request_params
         end

--- a/spec/warden/oauth2/strategies/bearer_spec.rb
+++ b/spec/warden/oauth2/strategies/bearer_spec.rb
@@ -28,5 +28,14 @@ describe Warden::OAuth2::Strategies::Bearer do
       subject.stub!(:params).and_return(:access_token => 'abc')
       subject.token_string_from_request_params.should == 'abc'
     end
+
+    it 'should fail if there is not a token' do
+      allow(subject).to receive(:params).and_return("access_token" => 'abc')
+      allow(subject).to receive(:token).and_return(nil)
+      subject.authenticate!
+      expect(subject.result).to eq(:failure)
+      expect(subject.message).to eq("invalid_token")
+      expect(subject.error_status).to eq(401)
+    end
   end
 end


### PR DESCRIPTION
In contrast to current behavior a 401 status code will be set if a token is sent, but was not found.  
